### PR TITLE
Updating pip requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,7 @@ Flask==1.0.2
 gunicorn==20.0.4
 isort==4.3.13
 itsdangerous==1.1.0
-Jinja2==2.10
+Jinja2==2.11.3
 lazy-object-proxy==1.3.1
 MarkupSafe==1.1.0
 mccabe==0.6.1
@@ -27,7 +27,7 @@ pytz==2020.1
 six==1.12.0
 sqlparse==0.4.1
 typed-ast==1.4.1
-Werkzeug==0.14.1
+Werkzeug==1.0.1
 whitenoise==5.2.0
 wrapt==1.11.1
 django-cors-headers==3.5.0


### PR DESCRIPTION
closes #77 
Updates some pip requirements definitions so that we close out the issues reported by dependabot found [here](https://github.com/2020SE691T2/RecessAPI/security/dependabot)